### PR TITLE
adding 2 tests & apply eslint to the tests

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,7 +1,9 @@
 module.exports = {
+    "root": true,
     "extends": "standard",
     "rules": {
         "semi": [2, "always"],
+        "indent": ["error", 2],
         "space-before-function-paren": ["error", "never"],
         "no-trailing-spaces": ["error", { "skipBlankLines": true }],
         "no-multiple-empty-lines": ["error", { "max": 4, "maxEOF": 2 }],

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "src/main.js",
   "scripts": {
     "test": "mocha tests/*.js",
-    "lint": "eslint src/**",
+    "lint": "eslint src/** tests/**",
     "coverage": "nyc npm test && nyc report --reporter=text-lcov | coveralls"
   },
   "author": "Xavier Decuyper <hi@savjee.be>",

--- a/tests/.eslintrc.js
+++ b/tests/.eslintrc.js
@@ -1,0 +1,8 @@
+module.exports = {
+    "extends": "../.eslintrc.js",
+    "globals": {
+        "describe": "readonly",
+        "it": "readonly",
+        "beforeEach": "readonly"
+    }
+}

--- a/tests/block.test.js
+++ b/tests/block.test.js
@@ -16,6 +16,14 @@ describe('Block class', function() {
             assert.deepEqual(blockObj.transactions, [createSignedTx()]);
             assert.equal(blockObj.nonce, 0);
         });
+
+        it('should correctly save parameters, without giving "previousHash"', function() {
+            blockObj = new Block(1000, [createSignedTx()]);
+            assert.equal(blockObj.previousHash, '');
+            assert.equal(blockObj.timestamp, 1000);
+            assert.deepEqual(blockObj.transactions, [createSignedTx()]);
+            assert.equal(blockObj.nonce, 0);
+        });
     });
 
     describe('Calculate hash', function() {

--- a/tests/block.test.js
+++ b/tests/block.test.js
@@ -1,75 +1,74 @@
 const assert = require('assert');
-const { Block, Transaction } = require('../src/blockchain');
+const { Block } = require('../src/blockchain');
 const { createSignedTx } = require('./helpers');
 
 let blockObj = null;
 
 beforeEach(function() {
-    blockObj = new Block(1000, [createSignedTx()], 'a1');
+  blockObj = new Block(1000, [createSignedTx()], 'a1');
 });
 
 describe('Block class', function() {
-    describe('Constructor', function() {
-        it('should correctly save parameters', function() {
-            assert.equal(blockObj.previousHash, 'a1');
-            assert.equal(blockObj.timestamp, 1000);
-            assert.deepEqual(blockObj.transactions, [createSignedTx()]);
-            assert.equal(blockObj.nonce, 0);
-        });
-
-        it('should correctly save parameters, without giving "previousHash"', function() {
-            blockObj = new Block(1000, [createSignedTx()]);
-            assert.equal(blockObj.previousHash, '');
-            assert.equal(blockObj.timestamp, 1000);
-            assert.deepEqual(blockObj.transactions, [createSignedTx()]);
-            assert.equal(blockObj.nonce, 0);
-        });
+  describe('Constructor', function() {
+    it('should correctly save parameters', function() {
+      assert.strict.equal(blockObj.previousHash, 'a1');
+      assert.strict.equal(blockObj.timestamp, 1000);
+      assert.strict.deepEqual(blockObj.transactions, [createSignedTx()]);
+      assert.strict.equal(blockObj.nonce, 0);
     });
 
-    describe('Calculate hash', function() {
-        it('should correct calculate the SHA256', function() {
-            blockObj.timestamp = 1;
-            blockObj.mineBlock(1);
+    it('should correctly save parameters, without giving "previousHash"', function() {
+      blockObj = new Block(1000, [createSignedTx()]);
+      assert.strict.equal(blockObj.previousHash, '');
+      assert.strict.equal(blockObj.timestamp, 1000);
+      assert.strict.deepEqual(blockObj.transactions, [createSignedTx()]);
+      assert.strict.equal(blockObj.nonce, 0);
+    });
+  });
 
-            assert.equal(
-                blockObj.hash,
-                '07d2992ddfcb8d538075fea2a6a33e7fb546c18038ae1a8c0214067ed66dc393'
-            );
-        });
+  describe('Calculate hash', function() {
+    it('should correct calculate the SHA256', function() {
+      blockObj.timestamp = 1;
+      blockObj.mineBlock(1);
 
-        it('should change when we tamper with the tx', function(){
-            const origHash = blockObj.calculateHash();
-            blockObj.timestamp = 100;
-
-            assert.notEqual(
-                blockObj.calculateHash(),
-                origHash
-            );
-        });
+      assert.strict.equal(
+        blockObj.hash,
+        '07d2992ddfcb8d538075fea2a6a33e7fb546c18038ae1a8c0214067ed66dc393'
+      );
     });
 
-    describe('has valid transactions', function(){
-        it('should return true with all valid tx', function(){
-            blockObj.transactions = [
-                createSignedTx(),
-                createSignedTx(),
-                createSignedTx(),
-            ];
+    it('should change when we tamper with the tx', function() {
+      const origHash = blockObj.calculateHash();
+      blockObj.timestamp = 100;
 
-            assert(blockObj.hasValidTransactions());
-        });
+      assert.strict.notEqual(
+        blockObj.calculateHash(),
+        origHash
+      );
+    });
+  });
 
-        it('should return false when a single tx is bad', function(){
-            const badTx = createSignedTx();
-            badTx.amount = 1337;
+  describe('has valid transactions', function() {
+    it('should return true with all valid tx', function() {
+      blockObj.transactions = [
+        createSignedTx(),
+        createSignedTx(),
+        createSignedTx()
+      ];
 
-            blockObj.transactions = [
-                createSignedTx(),
-                badTx
-            ];
-
-            assert(!blockObj.hasValidTransactions());
-        });
+      assert(blockObj.hasValidTransactions());
     });
 
+    it('should return false when a single tx is bad', function() {
+      const badTx = createSignedTx();
+      badTx.amount = 1337;
+
+      blockObj.transactions = [
+        createSignedTx(),
+        badTx
+      ];
+
+      assert(!blockObj.hasValidTransactions());
+    });
+  });
 });

--- a/tests/blockchain.test.js
+++ b/tests/blockchain.test.js
@@ -5,123 +5,123 @@ const { createSignedTx, signingKey, createBlockchainWithTx } = require('./helper
 let blockchain = null;
 
 beforeEach(function() {
-    blockchain = new Blockchain();
+  blockchain = new Blockchain();
 });
 
 describe('Blockchain class', function() {
-    describe('Constructor', function() {
-        it('should properly initialize fields', function() {
-        	assert.equal(blockchain.difficulty, 2);
-        	assert.deepEqual(blockchain.pendingTransactions, []);
-        	assert.equal(blockchain.miningReward, 100);
-        });
+  describe('Constructor', function() {
+    it('should properly initialize fields', function() {
+      assert.strict.equal(blockchain.difficulty, 2);
+      assert.strict.deepEqual(blockchain.pendingTransactions, []);
+      assert.strict.equal(blockchain.miningReward, 100);
+    });
+  });
+
+  describe('addTransaction', function() {
+    it('should correctly add new tx', function() {
+      const validTx = createSignedTx();
+      blockchain.addTransaction(validTx);
+
+      assert.strict.deepEqual(blockchain.pendingTransactions[0], validTx);
     });
 
-    describe('addTransaction', function(){
-    	it('should correctly add new tx', function(){
-    		const validTx = createSignedTx();
-    		blockchain.addTransaction(validTx);
+    it('should fail for tx without from address', function() {
+      const validTx = createSignedTx();
+      validTx.fromAddress = null;
 
-    		assert.deepEqual(blockchain.pendingTransactions[0], validTx);
-    	});
+      assert.throws(() => { blockchain.addTransaction(validTx); }, Error);
+    });
 
-    	it('should fail for tx without from address', function(){
-    		const validTx = createSignedTx();
-    		validTx.fromAddress = null;
+    it('should fail for tx without to address', function() {
+      const validTx = createSignedTx();
+      validTx.toAddress = null;
 
-    		assert.throws(() => { blockchain.addTransaction(validTx) }, Error);
-    	});
+      assert.throws(() => { blockchain.addTransaction(validTx); }, Error);
+    });
 
-    	it('should fail for tx without to address', function(){
-    		const validTx = createSignedTx();
-    		validTx.toAddress = null;
+    it('should fail when tx is not valid', function() {
+      const validTx = createSignedTx();
+      validTx.amount = 1000;
 
-    		assert.throws(() => { blockchain.addTransaction(validTx) }, Error);
-    	});
-
-    	it('should fail when tx is not valid', function(){
-    		const validTx = createSignedTx();
-    		validTx.amount = 1000;
-
-    		assert.throws(() => { blockchain.addTransaction(validTx) }, Error);
-    	});
+      assert.throws(() => { blockchain.addTransaction(validTx); }, Error);
+    });
         
-        it('should fail when tx has negative or zero amount', function() {
-            const tx1 = createSignedTx(0);
-            assert.throws(() => { blockchain.addTransaction(tx1) }, Error);
+    it('should fail when tx has negative or zero amount', function() {
+      const tx1 = createSignedTx(0);
+      assert.throws(() => { blockchain.addTransaction(tx1); }, Error);
 
-			const tx2 = createSignedTx(-20);
-            assert.throws(() => { blockchain.addTransaction(tx2) }, Error);
-        });
+      const tx2 = createSignedTx(-20);
+      assert.throws(() => { blockchain.addTransaction(tx2); }, Error);
+    });
+  });
+
+  describe('wallet balance', function() {
+    it('should give mining rewards', function() {
+      const validTx = createSignedTx();
+      blockchain.addTransaction(validTx);
+      blockchain.addTransaction(validTx);
+
+      blockchain.minePendingTransactions('b2');
+
+      assert.strict.equal(blockchain.getBalanceOfAddress('b2'), 100);
     });
 
-    describe('wallet balance', function(){
-    	it('should give mining rewards', function(){
-    		const validTx = createSignedTx();
-    		blockchain.addTransaction(validTx);
-    		blockchain.addTransaction(validTx);
+    it('should correctly reduce wallet balance', function() {
+      const walletAddr = signingKey.getPublic('hex');
+      blockchain = createBlockchainWithTx();
 
-    		blockchain.minePendingTransactions("b2");
+      blockchain.minePendingTransactions(walletAddr);
+      assert.strict.equal(blockchain.getBalanceOfAddress(walletAddr), 80);
+    });
+  });
 
-    		assert.equal(blockchain.getBalanceOfAddress("b2"), 100);
-    	});
+  describe('helper functions', function() {
+    it('should correctly set first block to genesis block', function() {
+      assert.strict.deepEqual(blockchain.chain[0], blockchain.createGenesisBlock());
+    });
+  });
 
-    	it('should correctly reduce wallet balance', function(){
-    		const walletAddr = signingKey.getPublic('hex');
-    		blockchain = createBlockchainWithTx();
-
-    		blockchain.minePendingTransactions(walletAddr);
-    		assert.equal(blockchain.getBalanceOfAddress(walletAddr), 80);
-    	});
+  describe('isChainValid', function() {
+    it('should return true if no tampering', function() {
+      blockchain = createBlockchainWithTx();
+      assert(blockchain.isChainValid());
     });
 
-    describe('helper functions', function(){
-    	it('should correctly set first block to genesis block', function(){
-    		assert.deepEqual(blockchain.chain[0], blockchain.createGenesisBlock());
-    	});
+    it('should fail when genesis block has been tampered with', function() {
+      blockchain.chain[0].timestamp = 39708;
+      assert(!blockchain.isChainValid());
     });
 
-    describe('isChainValid', function(){
-    	it('should return true if no tampering', function(){
-    		blockchain = createBlockchainWithTx();
-    		assert(blockchain.isChainValid());
-    	});
+    it('should fail when a tx is invalid', function() {
+      blockchain = createBlockchainWithTx();
+      blockchain.chain[1].transactions[0].amount = 897397;
+      assert(!blockchain.isChainValid());
+    });
 
-    	it('should fail when genesis block has been tampered with', function(){
-    		blockchain.chain[0].timestamp = 39708;
-    		assert(!blockchain.isChainValid());
-    	});
+    it('should fail when a block has been changed', function() {
+      blockchain = createBlockchainWithTx();
+      blockchain.chain[1].timestamp = 897397;
+      assert(!blockchain.isChainValid());
+    });
+  });
+  
+  describe('getAllTransactionsForWallet', function() {
+    it('should get all Transactions for a Wallet', function() {
+      const validTx = createSignedTx();
+      blockchain.addTransaction(validTx);
+      blockchain.addTransaction(validTx);
 
-    	it('should fail when a tx is invalid', function(){
-    		blockchain = createBlockchainWithTx();
-    		blockchain.chain[1].transactions[0].amount = 897397;
-    		assert(!blockchain.isChainValid());
-		});
+      blockchain.minePendingTransactions('b2');
+      blockchain.addTransaction(validTx);
+      blockchain.addTransaction(validTx);
+      blockchain.minePendingTransactions('b2');
 
-    	it('should fail when a block has been changed', function(){
-    		blockchain = createBlockchainWithTx();
-    		blockchain.chain[1].timestamp = 897397;
-    		assert(!blockchain.isChainValid());
-    	});
-	});
-	
-	describe("getAllTransactionsForWallet", function(){
-		it("should get all Transactions for a Wallet", function() {
-			const validTx = createSignedTx();
-    		blockchain.addTransaction(validTx);
-    		blockchain.addTransaction(validTx);
-
-			blockchain.minePendingTransactions("b2");
-			blockchain.addTransaction(validTx);
-			blockchain.addTransaction(validTx);
-			blockchain.minePendingTransactions("b2");
-
-			for (const trans of blockchain.getAllTransactionsForWallet("b2")) {
-				assert.equal(trans.amount, 100);
-				assert.equal(trans.fromAddress, null);
-				assert.equal(trans.toAddress, "b2");
-				// timestamp cant be verified?
-			}
-		});
-	});
+      for (const trans of blockchain.getAllTransactionsForWallet('b2')) {
+        assert.strict.equal(trans.amount, 100);
+        assert.strict.equal(trans.fromAddress, null);
+        assert.strict.equal(trans.toAddress, 'b2');
+        // timestamp cant be verified?
+      }
+    });
+  });
 });

--- a/tests/blockchain.test.js
+++ b/tests/blockchain.test.js
@@ -116,11 +116,11 @@ describe('Blockchain class', function() {
       blockchain.addTransaction(validTx);
       blockchain.minePendingTransactions('b2');
 
+      assert.strict.equal(blockchain.getAllTransactionsForWallet('b2').length, 2);
       for (const trans of blockchain.getAllTransactionsForWallet('b2')) {
         assert.strict.equal(trans.amount, 100);
         assert.strict.equal(trans.fromAddress, null);
         assert.strict.equal(trans.toAddress, 'b2');
-        // timestamp cant be verified?
       }
     });
   });

--- a/tests/blockchain.test.js
+++ b/tests/blockchain.test.js
@@ -1,5 +1,5 @@
 const assert = require('assert');
-const { Blockchain, Transaction } = require('../src/blockchain');
+const { Blockchain } = require('../src/blockchain');
 const { createSignedTx, signingKey, createBlockchainWithTx } = require('./helpers');
 
 let blockchain = null;
@@ -88,12 +88,32 @@ describe('Blockchain class', function() {
     		blockchain = createBlockchainWithTx();
     		blockchain.chain[1].transactions[0].amount = 897397;
     		assert(!blockchain.isChainValid());
-    	});
+		});
 
     	it('should fail when a block has been changed', function(){
     		blockchain = createBlockchainWithTx();
     		blockchain.chain[1].timestamp = 897397;
     		assert(!blockchain.isChainValid());
     	});
-    });
+	});
+	
+	describe("getAllTransactionsForWallet", function(){
+		it("should get all Transactions for a Wallet", function() {
+			const validTx = createSignedTx();
+    		blockchain.addTransaction(validTx);
+    		blockchain.addTransaction(validTx);
+
+			blockchain.minePendingTransactions("b2");
+			blockchain.addTransaction(validTx);
+			blockchain.addTransaction(validTx);
+			blockchain.minePendingTransactions("b2");
+
+			blockchain.getAllTransactionsForWallet("b2").forEach((x) => {
+				assert.equal(x.amount, 100);
+				assert.equal(x.fromAddress, null);
+				assert.equal(x.toAddress, "b2");
+				// timestamp cant be verified?
+			});
+		});
+	});
 });

--- a/tests/blockchain.test.js
+++ b/tests/blockchain.test.js
@@ -116,12 +116,12 @@ describe('Blockchain class', function() {
 			blockchain.addTransaction(validTx);
 			blockchain.minePendingTransactions("b2");
 
-			blockchain.getAllTransactionsForWallet("b2").forEach((x) => {
-				assert.equal(x.amount, 100);
-				assert.equal(x.fromAddress, null);
-				assert.equal(x.toAddress, "b2");
+			for (const trans of blockchain.getAllTransactionsForWallet("b2")) {
+				assert.equal(trans.amount, 100);
+				assert.equal(trans.fromAddress, null);
+				assert.equal(trans.toAddress, "b2");
 				// timestamp cant be verified?
-			});
+			}
 		});
 	});
 });

--- a/tests/helpers.js
+++ b/tests/helpers.js
@@ -1,27 +1,27 @@
-const { Transaction, Block, Blockchain } = require('../src/blockchain');
+const { Transaction, Blockchain } = require('../src/blockchain');
 const EC = require('elliptic').ec;
 const ec = new EC('secp256k1');
 const signingKey = ec.keyFromPrivate('3d6f54430830d388052865b95c10b4aeb1bbe33c01334cf2cfa8b520062a0ce3');
 
-function createSignedTx(amount = 10){
-	const txObject = new Transaction(signingKey.getPublic('hex'), 'wallet2', amount);
-    txObject.timestamp = 1;
-    txObject.signTransaction(signingKey);
+function createSignedTx(amount = 10) {
+  const txObject = new Transaction(signingKey.getPublic('hex'), 'wallet2', amount);
+  txObject.timestamp = 1;
+  txObject.signTransaction(signingKey);
 
-    return txObject;
+  return txObject;
 }
 
-function createBlockchainWithTx(){
-	const blockchain = new Blockchain();
-	const walletAddr = signingKey.getPublic('hex');
-	const validTx = new Transaction(walletAddr, 'b2', 10);
-	validTx.signTransaction(signingKey);
+function createBlockchainWithTx() {
+  const blockchain = new Blockchain();
+  const walletAddr = signingKey.getPublic('hex');
+  const validTx = new Transaction(walletAddr, 'b2', 10);
+  validTx.signTransaction(signingKey);
 
-	blockchain.addTransaction(validTx);
-	blockchain.addTransaction(validTx);
-	blockchain.minePendingTransactions(1);
+  blockchain.addTransaction(validTx);
+  blockchain.addTransaction(validTx);
+  blockchain.minePendingTransactions(1);
 
-	return blockchain;
+  return blockchain;
 }
 
 module.exports.signingKey = signingKey;

--- a/tests/transaction.test.js
+++ b/tests/transaction.test.js
@@ -5,102 +5,101 @@ const { createSignedTx, signingKey } = require('./helpers');
 let txObject = null;
 
 beforeEach(function() {
-    txObject = new Transaction('fromAddress', 'toAddress', 9999);
+  txObject = new Transaction('fromAddress', 'toAddress', 9999);
 });
 
 describe('Transaction class', function() {
-    describe('Constructor', function() {
-        it('should automatically set the current date', function() {
-            const actual = txObject.timestamp;
-            const minTime = Date.now() - 1000;
-            const maxTime = Date.now() + 1000;
+  describe('Constructor', function() {
+    it('should automatically set the current date', function() {
+      const actual = txObject.timestamp;
+      const minTime = Date.now() - 1000;
+      const maxTime = Date.now() + 1000;
 
-            assert(actual > minTime && actual < maxTime, 'Tx does not have a good timestamp');
-        });
-
-
-        it('should correctly save from, to and amount', function() {
-            txObject = new Transaction('a1', 'b1', 10);
-
-            assert.equal(txObject.fromAddress, 'a1');
-            assert.equal(txObject.toAddress, 'b1');
-            assert.equal(txObject.amount, 10);
-        });
+      assert(actual > minTime && actual < maxTime, 'Tx does not have a good timestamp');
     });
 
-    describe('Calculate hash', function() {
-        it('should correct calculate the SHA256', function() {
-            txObject = new Transaction('a1', 'b1', 10);
-            txObject.timestamp = 1;
 
-            assert.equal(
-                txObject.calculateHash(),
+    it('should correctly save from, to and amount', function() {
+      txObject = new Transaction('a1', 'b1', 10);
 
-                // Output of SHA256(a1b1101)
-                '21894bb7b0e56aab9eb48d4402d94628a9a179bc277542a5703f417900275153'
-            );
-        });
+      assert.strict.equal(txObject.fromAddress, 'a1');
+      assert.strict.equal(txObject.toAddress, 'b1');
+      assert.strict.equal(txObject.amount, 10);
+    });
+  });
 
-        it('should change when we tamper with the tx', function(){
-        	txObject = new Transaction('a1', 'b1', 10);
+  describe('Calculate hash', function() {
+    it('should correct calculate the SHA256', function() {
+      txObject = new Transaction('a1', 'b1', 10);
+      txObject.timestamp = 1;
 
-        	const originalHash = txObject.calculateHash();
-            txObject.amount = 100;
+      assert.strict.equal(
+        txObject.calculateHash(),
 
-            assert.notEqual(
-            	txObject.calculateHash(),
-            	originalHash
-            );
-        });
+        // Output of SHA256(a1b1101)
+        '21894bb7b0e56aab9eb48d4402d94628a9a179bc277542a5703f417900275153'
+      );
     });
 
-    describe('isValid', function() {
-        it('should throw error without signature', function() {
-            assert.throws(() => { txObject.isValid() }, Error);
-        });
+    it('should change when we tamper with the tx', function() {
+      txObject = new Transaction('a1', 'b1', 10);
 
-        it('should correctly sign transactions', function(){
-        	txObject = createSignedTx();
+      const originalHash = txObject.calculateHash();
+      txObject.amount = 100;
 
-        	assert.equal(
-        		txObject.signature,
-        		'3044022023fb1d818a0888f7563e1a3ccdd68b28e23070d6c0c1c5'+
-        		'004721ee1013f1d769022037da026cda35f95ef1ee5ced5b9f7d70'+
-        		'e102fcf841e6240950c61e8f9b6ef9f8'
-        	);
-        });
+      assert.strict.notEqual(
+        txObject.calculateHash(),
+        originalHash
+      );
+    });
+  });
 
-        it('should not sign transactions for other wallets', function(){
-        	txObject = new Transaction('not a correct wallet key', 'wallet2', 10);
-        	txObject.timestamp = 1;
-
-        	assert.throws(() => {
-        		txObject.signTransaction(signingKey);
-        	}, Error);
-        });
-
-        it('should detect badly signed transactions', function(){
-        	txObject = createSignedTx();
-
-        	// Tamper with it & it should be invalid!
-        	txObject.amount = 100;
-        	assert(!txObject.isValid());
-        });
-
-        it('should return true with correctly signed tx', function(){
-        	txObject = createSignedTx();
-        	assert(txObject.isValid());
-        });
-
-        it('should fail when signature is empty string', function(){
-        	txObject.signature = '';
-        	assert.throws(() => {txObject.isValid()}, Error);
-        });
-
-        it('should return true for mining rewards', function(){
-        	txObject.fromAddress = null;
-        	assert(txObject.isValid());
-        })
+  describe('isValid', function() {
+    it('should throw error without signature', function() {
+      assert.throws(() => { txObject.isValid(); }, Error);
     });
 
+    it('should correctly sign transactions', function() {
+      txObject = createSignedTx();
+
+      assert.strict.equal(
+        txObject.signature,
+        '3044022023fb1d818a0888f7563e1a3ccdd68b28e23070d6c0c1c5' +
+'004721ee1013f1d769022037da026cda35f95ef1ee5ced5b9f7d70' +
+'e102fcf841e6240950c61e8f9b6ef9f8'
+      );
+    });
+
+    it('should not sign transactions for other wallets', function() {
+      txObject = new Transaction('not a correct wallet key', 'wallet2', 10);
+      txObject.timestamp = 1;
+
+      assert.throws(() => {
+        txObject.signTransaction(signingKey);
+      }, Error);
+    });
+
+    it('should detect badly signed transactions', function() {
+      txObject = createSignedTx();
+
+      // Tamper with it & it should be invalid!
+      txObject.amount = 100;
+      assert(!txObject.isValid());
+    });
+
+    it('should return true with correctly signed tx', function() {
+      txObject = createSignedTx();
+      assert(txObject.isValid());
+    });
+
+    it('should fail when signature is empty string', function() {
+      txObject.signature = '';
+      assert.throws(() => { txObject.isValid(); }, Error);
+    });
+
+    it('should return true for mining rewards', function() {
+      txObject.fromAddress = null;
+      assert(txObject.isValid());
+    });
+  });
 });


### PR DESCRIPTION
adding tests for:
- correctly save parameters, without giving "previousHash"
- BlockChain.getAllTransactionsForWallet

bringing coverage to about 99%

adding eslint to the tests