### PR TITLE
remove unnecessary function

### DIFF
--- a/src/blockchain.js
+++ b/src/blockchain.js
@@ -264,10 +264,6 @@ class Blockchain {
       if (currentBlock.hash !== currentBlock.calculateHash()) {
         return false;
       }
-
-      if (currentBlock.previousHash !== previousBlock.calculateHash()) {
-        return false;
-      }
     }
 
     return true;

--- a/src/blockchain.js
+++ b/src/blockchain.js
@@ -255,7 +255,6 @@ class Blockchain {
     // signatures are correct
     for (let i = 1; i < this.chain.length; i++) {
       const currentBlock = this.chain[i];
-      const previousBlock = this.chain[i - 1];
 
       if (!currentBlock.hasValidTransactions()) {
         return false;


### PR DESCRIPTION
i couldnt think of any instance where "currentBlock.calculateHash" wouldnt fail and "previousBlock.calculateHash" would go in
-> i could be wrong, just wanting to point this out
(and when this and #23 the coverage would go up to nearly 100%)