### PR TITLE
refactor: make tests of `Transaction` class to self contain with few minor improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ const myChain = new Blockchain();
 ```js
 // Transfer 100 coins from my wallet to "toAddress"
 const tx = new Transaction(myKey.getPublic('hex'), 'toAddress', 100);
-tx.signTransaction(myKey);
+tx.sign(myKey);
 
 myChain.addTransaction(tx);
 ```

--- a/src/blockchain.js
+++ b/src/blockchain.js
@@ -36,7 +36,7 @@ class Transaction {
    *
    * @param {string} signingKey
    */
-  signTransaction(signingKey) {
+  sign(signingKey) {
     // You can only send a transaction from the wallet that is linked to your
     // key. So here we check if the fromAddress matches your publicKey
     if (signingKey.getPublic('hex') !== this.fromAddress) {

--- a/src/main.js
+++ b/src/main.js
@@ -19,7 +19,7 @@ savjeeCoin.minePendingTransactions(myWalletAddress);
 
 // Create a transaction & sign it with your key
 const tx1 = new Transaction(myWalletAddress, 'address2', 100);
-tx1.signTransaction(myKey);
+tx1.sign(myKey);
 savjeeCoin.addTransaction(tx1);
 
 // Mine block
@@ -27,7 +27,7 @@ savjeeCoin.minePendingTransactions(myWalletAddress);
 
 // Create second transaction
 const tx2 = new Transaction(myWalletAddress, 'address1', 50);
-tx2.signTransaction(myKey);
+tx2.sign(myKey);
 savjeeCoin.addTransaction(tx2);
 
 // Mine block

--- a/tests/blockchain.test.js
+++ b/tests/blockchain.test.js
@@ -94,7 +94,7 @@ describe('Blockchain class', function() {
       // Create new transaction to self
       const tx = new Transaction(walletAddr, walletAddr, 80);
       tx.timestamp = 1;
-      tx.signTransaction(signingKey);
+      tx.sign(signingKey);
 
       blockchain.addTransaction(tx);
       blockchain.minePendingTransactions('no_addr');

--- a/tests/helpers.js
+++ b/tests/helpers.js
@@ -6,7 +6,7 @@ const signingKey = ec.keyFromPrivate('3d6f54430830d388052865b95c10b4aeb1bbe33c01
 function createSignedTx(amount = 10) {
   const txObject = new Transaction(signingKey.getPublic('hex'), 'wallet2', amount);
   txObject.timestamp = 1;
-  txObject.signTransaction(signingKey);
+  txObject.sign(signingKey);
 
   return txObject;
 }
@@ -23,7 +23,7 @@ function createBlockchainWithTx() {
   blockchain.minePendingTransactions(signingKey.getPublic('hex'));
 
   const validTx = new Transaction(signingKey.getPublic('hex'), 'b2', 10);
-  validTx.signTransaction(signingKey);
+  validTx.sign(signingKey);
 
   blockchain.addTransaction(validTx);
   blockchain.addTransaction(validTx);

--- a/tests/transaction.test.js
+++ b/tests/transaction.test.js
@@ -1,25 +1,20 @@
 const assert = require('assert');
-const EC = require('elliptic').ec;
 
 const { Transaction } = require('../src/blockchain');
+const { createSignedTx, signingKey } = require('./helpers');
 
 describe('Transaction class', function() {
   let txObject = null;
-  const signingKey = (new EC('secp256k1')).keyFromPrivate('some-private-key');
-  const fromAddress = signingKey.getPublic('hex');
-  const toAddress = signingKey.getPublic('hex');
+  const fromAddress = 'fromAddress';
+  const toAddress = 'toAddress';
   const amount = 100;
 
   beforeEach(function() {
     txObject = new Transaction(fromAddress, toAddress, amount);
-    txObject.timestamp = 1;
-    txObject.sign(signingKey);
   });
 
   describe('constructor', function() {
     it('should automatically set the current date', function() {
-      txObject = new Transaction(fromAddress, toAddress, amount);
-      
       const actual = txObject.timestamp;
       const minTime = Date.now() - 1000;
       const maxTime = Date.now() + 1000;
@@ -36,9 +31,11 @@ describe('Transaction class', function() {
 
   describe('calculateHash', function() {
     it('should correctly calculate the SHA256 hash', function() {
+      txObject.timestamp = 1;
+
       assert.strict.equal(
         txObject.calculateHash(),
-        '8e8e081788cba59d0e11fc881dab1f7fbe7eb3dd4f7db9d6382c892588cc912a'
+        '4be9c20f87f7baac191aa246a33b5d44af1f96f23598ac06e5f71ee222f40abf'
       );
     });
 
@@ -55,10 +52,12 @@ describe('Transaction class', function() {
 
   describe('sign', function() {
     it('should correctly sign transactions', function() {
+      txObject = createSignedTx();
+
       assert.strict.equal(
         txObject.signature,
-        '3046022100b2e5ee31c4ebea01125c73c8ef031b35e23f58f363a2ba732860f512ad99b1' +
-        '0b022100b89da6fff470eac3d085276dd7ce079e6d0b049181226eaf45ab0b43ecc6a0fd'
+        '3044022023fb1d818a0888f7563e1a3ccdd68b28e23070d6c0c1c5004721ee1013f1d7' +
+        '69022037da026cda35f95ef1ee5ced5b9f7d70e102fcf841e6240950c61e8f9b6ef9f8'
       );
     });
 
@@ -86,6 +85,8 @@ describe('Transaction class', function() {
     });
 
     it('should return false for badly signed transactions', function() {
+      txObject = createSignedTx(10);
+
       // Tamper the amount making the signature invalid
       txObject.amount = 50;
 
@@ -93,6 +94,7 @@ describe('Transaction class', function() {
     });
 
     it('should return true for correctly signed tx', function() {
+      txObject = createSignedTx(10);
       assert(txObject.isValid());
     });
   });

--- a/tests/transaction.test.js
+++ b/tests/transaction.test.js
@@ -1,5 +1,4 @@
 const assert = require('assert');
-const crypto = require('crypto');
 const EC = require('elliptic').ec;
 
 const { Transaction } = require('../src/blockchain');
@@ -13,11 +12,14 @@ describe('Transaction class', function() {
 
   beforeEach(function() {
     txObject = new Transaction(fromAddress, toAddress, amount);
+    txObject.timestamp = 1;
     txObject.sign(signingKey);
   });
 
   describe('constructor', function() {
     it('should automatically set the current date', function() {
+      txObject = new Transaction(fromAddress, toAddress, amount);
+      
       const actual = txObject.timestamp;
       const minTime = Date.now() - 1000;
       const maxTime = Date.now() + 1000;
@@ -34,11 +36,9 @@ describe('Transaction class', function() {
 
   describe('calculateHash', function() {
     it('should correctly calculate the SHA256 hash', function() {
-      const expectedHash = crypto.createHash('sha256').update(txObject.fromAddress + txObject.toAddress + txObject.amount + txObject.timestamp).digest('hex');
-
       assert.strict.equal(
         txObject.calculateHash(),
-        expectedHash
+        '8e8e081788cba59d0e11fc881dab1f7fbe7eb3dd4f7db9d6382c892588cc912a'
       );
     });
 
@@ -55,13 +55,10 @@ describe('Transaction class', function() {
 
   describe('sign', function() {
     it('should correctly sign transactions', function() {
-      const hashTx = txObject.calculateHash();
-      const sig = signingKey.sign(hashTx, 'base64');
-      const expectedSignature = sig.toDER('hex');
-
       assert.strict.equal(
         txObject.signature,
-        expectedSignature
+        '3046022100b2e5ee31c4ebea01125c73c8ef031b35e23f58f363a2ba732860f512ad99b1' +
+        '0b022100b89da6fff470eac3d085276dd7ce079e6d0b049181226eaf45ab0b43ecc6a0fd'
       );
     });
 

--- a/tests/transaction.test.js
+++ b/tests/transaction.test.js
@@ -13,10 +13,10 @@ describe('Transaction class', function() {
 
   beforeEach(function() {
     txObject = new Transaction(fromAddress, toAddress, amount);
-    txObject.sign(signingKey)
+    txObject.sign(signingKey);
   });
 
-  describe('constructor', function() {  
+  describe('constructor', function() {
     it('should automatically set the current date', function() {
       const actual = txObject.timestamp;
       const minTime = Date.now() - 1000;
@@ -34,7 +34,7 @@ describe('Transaction class', function() {
 
   describe('calculateHash', function() {
     it('should correctly calculate the SHA256 hash', function() {
-      const expectedHash = crypto.createHash('sha256').update(txObject.fromAddress + txObject.toAddress + txObject.amount + txObject.timestamp).digest('hex')
+      const expectedHash = crypto.createHash('sha256').update(txObject.fromAddress + txObject.toAddress + txObject.amount + txObject.timestamp).digest('hex');
 
       assert.strict.equal(
         txObject.calculateHash(),
@@ -66,13 +66,13 @@ describe('Transaction class', function() {
     });
 
     it('should not sign transactions with fromAddresses that does not belogs to the private key', function() {
-      txObject.fromAddress = 'some-other-address'
+      txObject.fromAddress = 'some-other-address';
 
       assert.throws(() => {
         txObject.sign(signingKey);
       }, Error);
     });
-  })
+  });
 
   describe('isValid', function() {
     it('should return true for mining reward transactions', function() {


### PR DESCRIPTION
This PR refactors the tests of transaction class to be clearer.

- [ ] ~~Remove using the external helper function `createSignedTx`.~~
- [x] Update method name `signTransaction` to just `sign`., As it's in the `Transaction` class making it unnecessary to include the term `Transaction` considering that it is the only signing done inside a transaction.
- [x] Add `describe:sign`, previously had these tests also done inside `describe:isValid`.
- [ ] ~~Instead of using hardcoded values in assertions (signatures and hashes), use dynamic values so that they can be true even if the test data changes.~~

If these changes are acceptable, I would be more than happy to update other tests also in another PR(s).

